### PR TITLE
Fix build stack traceback in DebugLib #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
-bin
-target
-build
-lib
-jit
+bin/
+target/
+build/
+lib/
+jit/
 *.ser
 *.gz
 *.jar

--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html>
+# This is a fork!
+<div style="border: 1px dotted red; margin: 1.em 0.5em; font-weight: bold; color: red;">
+This repository has been forked from the original CVS sources of Luaj.
+The commit history has been converted to make sure that the original work of
+James Roseborough and Ian Farmer is not lost.
+Unfortunately, I was not able to contact either James or Ian to hand over
+ownership of the Github organization/repo as I have originally intended to.
+The community however seems interested enough to continue work on the original
+sources and therefore I have decided to make sure that any useful pull requests
+that may add some value to the original code base shall be merged in from now
+on.<br>
+-- Benjamin P. Jung, Jan. 26th 2018
+</div>
 
-<head>
-<title>Getting Started with LuaJ</title>
-<link rel="stylesheet" type="text/css" href="http://www.lua.org/lua.css">
-<META HTTP-EQUIV="content-type" CONTENT="text/html; charset=iso-8859-1">
-</head>
-
-<body>
-
-<hr>
-<h1>
-<a href="README.html"><img src="http://sourceforge.net/dbimage.php?id=196139" alt="" border="0"></a>
-
-Getting Started with LuaJ
-
-</h1>
+<h1>Getting Started with LuaJ</h1>
 James Roseborough, Ian Farmer, Version 3.0.1
 <p>
 <small>

--- a/src/core/org/luaj/vm2/lib/DebugLib.java
+++ b/src/core/org/luaj/vm2/lib/DebugLib.java
@@ -867,6 +867,10 @@ public class DebugLib extends TwoArgFunction {
 	        if (reg == a) setreg = pc;  /* jumped code can change 'a' */
 	        break;
 	      }
+	      case Lua.OP_SETLIST: { // Lua.testAMode(Lua.OP_SETLIST) == false
+	    	if ( ((i>>14)&0x1ff) == 0 ) pc++; // if c == 0 then c stored in next op -> skip
+		break;
+	      }
 	      default:
 	        if (Lua.testAMode(op) && reg == a)  /* any instruction that set A */
 	          setreg = pc;


### PR DESCRIPTION
If create huge table with a lot items (> 28000) then additional op code for store `c` out of range of op codes and this loop crash.
This PR add case for OP_SETLIST for skip next op if in it stored `c`.
OP_SETLIST not AMode OP 
https://github.com/luaj/luaj/blob/70cb74b4d65851ef69240d35b58d9f8d20a73ed1/src/core/org/luaj/vm2/Lua.java#L319
https://github.com/luaj/luaj/blob/70cb74b4d65851ef69240d35b58d9f8d20a73ed1/src/core/org/luaj/vm2/Lua.java#L335