### PR TITLE
Fix build stack traceback in DebugLib #7

### DIFF
--- a/src/core/org/luaj/vm2/lib/DebugLib.java
+++ b/src/core/org/luaj/vm2/lib/DebugLib.java
@@ -867,6 +867,10 @@ public class DebugLib extends TwoArgFunction {
 	        if (reg == a) setreg = pc;  /* jumped code can change 'a' */
 	        break;
 	      }
+	      case Lua.OP_SETLIST: { // Lua.testAMode(Lua.OP_SETLIST) == false
+	    	if ( ((i>>14)&0x1ff) == 0 ) pc++; // if c == 0 then c stored in next op -> skip
+		break;
+	      }
 	      default:
 	        if (Lua.testAMode(op) && reg == a)  /* any instruction that set A */
 	          setreg = pc;


### PR DESCRIPTION
If create huge table with a lot items (> 28000) then additional op code for store `c` out of range of op codes and this loop crash.
This PR add case for OP_SETLIST for skip next op if in it stored `c`.
OP_SETLIST not AMode OP 
https://github.com/luaj/luaj/blob/70cb74b4d65851ef69240d35b58d9f8d20a73ed1/src/core/org/luaj/vm2/Lua.java#L319
https://github.com/luaj/luaj/blob/70cb74b4d65851ef69240d35b58d9f8d20a73ed1/src/core/org/luaj/vm2/Lua.java#L335