### PR TITLE
Fixed LuaJC not writing java package to bytecode correctly

### DIFF
--- a/src/jse/luajc.java
+++ b/src/jse/luajc.java
@@ -189,8 +189,10 @@ public class luajc {
 
 		public Class findClass(String classname) throws ClassNotFoundException {
 			 byte[] bytes = (byte[]) t.get(classname);
-			 if ( bytes != null )
+			 if ( bytes != null ) {
+				 classname = classname.replace('/', '.');
 				 return defineClass(classname, bytes, 0, bytes.length);
+			 }
 			 return super.findClass(classname);
 		 }
 	}

--- a/src/jse/org/luaj/vm2/luajc/LuaJC.java
+++ b/src/jse/org/luaj/vm2/luajc/LuaJC.java
@@ -114,7 +114,24 @@ public class LuaJC implements Globals.Loader {
 		StringBuffer classname = new StringBuffer();
 		for (int i = 0, n = stub.length(); i < n; ++i) {
 			final char c = stub.charAt(i);
-			classname.append((((i == 0) && Character.isJavaIdentifierStart(c)) || ((i > 0) && Character.isJavaIdentifierPart(c)))? c: '_');
+			switch(i) {
+			case 0:
+				if(Character.isJavaIdentifierStart(c)) {
+					classname.append(c);
+				} else {
+					classname.append('_');
+				}
+				break;
+			default:
+				if(c == '/') {
+					classname.append(c);
+				} else if(Character.isJavaIdentifierPart(c)) {
+					classname.append(c);
+				} else {
+					classname.append('_');
+				}
+				break;
+			}
 		}
 		return classname.toString();
 	}


### PR DESCRIPTION
(Note: I encountered this issue earlier today in https://github.com/mini2Dx/miniscript/ )

LuaJC was transforming package names (e.g. `org.example.ExampleClass`) to class name prefixes (e.g. `org_example_ExampleClass`) with the default package being used. Based on the command line args, it should come out as class `ExampleClass` with package `org.example`

The following commit fixes the issue.