### PR TITLE
Fix build bug. #33

### DIFF
--- a/examples/jse/SampleApplet.java
+++ b/examples/jse/SampleApplet.java
@@ -17,7 +17,7 @@ import org.luaj.vm2.lib.jse.JseBaseLib;
 import org.luaj.vm2.lib.jse.JseIoLib;
 import org.luaj.vm2.lib.jse.JseMathLib;
 import org.luaj.vm2.lib.jse.JseOsLib;
-import org.luaj.vm2.lib.jse.JseStringLib;
+import org.luaj.vm2.lib.jse.StringLib;
 import org.luaj.vm2.lib.jse.LuajavaLib;
 
 /**
@@ -76,7 +76,7 @@ public class SampleApplet extends Applet implements ResourceFinder {
 		globals.load(new PackageLib());
 		globals.load(new Bit32Lib());
 		globals.load(new TableLib());
-		globals.load(new JseStringLib());
+		globals.load(new StringLib());
 		globals.load(new CoroutineLib());
 		globals.load(new JseMathLib());
 		globals.load(new JseIoLib());

--- a/examples/jse/SampleSandboxed.java
+++ b/examples/jse/SampleSandboxed.java
@@ -15,7 +15,7 @@ import org.luaj.vm2.lib.TwoArgFunction;
 import org.luaj.vm2.lib.ZeroArgFunction;
 import org.luaj.vm2.lib.jse.JseBaseLib;
 import org.luaj.vm2.lib.jse.JseMathLib;
-import org.luaj.vm2.lib.jse.JseStringLib;
+import org.luaj.vm2.lib.jse.StringLib;
 
 /** Simple program that illustrates basic sand-boxing of client scripts
  * in a server environment.
@@ -43,7 +43,7 @@ public class SampleSandboxed {
 		server_globals = new Globals();
 		server_globals.load(new JseBaseLib());
 		server_globals.load(new PackageLib());
-		server_globals.load(new JseStringLib());
+		server_globals.load(new StringLib());
 
 		// To load scripts, we occasionally need a math library in addition to compiler support.
 		// To limit scripts using the debug library, they must be closures, so we only install LuaC.
@@ -96,7 +96,7 @@ public class SampleSandboxed {
 		user_globals.load(new PackageLib());
 		user_globals.load(new Bit32Lib());
 		user_globals.load(new TableLib());
-		user_globals.load(new JseStringLib());
+		user_globals.load(new StringLib());
 		user_globals.load(new JseMathLib());
 
 		// This library is dangerous as it gives unfettered access to the

--- a/src/core/org/luaj/vm2/lib/StringLib.java
+++ b/src/core/org/luaj/vm2/lib/StringLib.java
@@ -49,7 +49,7 @@ import org.luaj.vm2.compiler.DumpState;
  * Globals globals = new Globals();
  * globals.load(new JseBaseLib());
  * globals.load(new PackageLib());
- * globals.load(new JseStringLib());
+ * globals.load(new StringLib());
  * System.out.println( globals.get("string").get("upper").call( LuaValue.valueOf("abcde") ) );
  * } </pre>
  * <p>

--- a/src/jse/org/luaj/vm2/lib/jse/JsePlatform.java
+++ b/src/jse/org/luaj/vm2/lib/jse/JsePlatform.java
@@ -97,7 +97,7 @@ public class JsePlatform {
 		globals.load(new PackageLib());
 		globals.load(new Bit32Lib());
 		globals.load(new TableLib());
-		globals.load(new JseStringLib());
+		globals.load(new StringLib());
 		globals.load(new CoroutineLib());
 		globals.load(new JseMathLib());
 		globals.load(new JseIoLib());


### PR DESCRIPTION
```
  [javac] /.../luaj/build/jse/src/org/luaj/vm2/lib/jse/JsePlatform.
java:100: error: cannot find symbol
    [javac]             globals.load(new JseStringLib());
    [javac]                              ^
    [javac]   symbol:   class JseStringLib
    [javac]   location: class JsePlatform
    [javac] 1 error
    [javac] 4 warnings
```