### PR TITLE
Assorted fixes

### DIFF
--- a/src/core/org/luaj/vm2/LuaClosure.java
+++ b/src/core/org/luaj/vm2/LuaClosure.java
@@ -548,7 +548,7 @@ public class LuaClosure extends LuaFunction {
 
 	private void processErrorHooks(LuaError le, Prototype p, int pc) {
 		le.fileline = (p.source != null? p.source.tojstring(): "?") + ":"
-			+ (p.lineinfo != null && pc >= 0 && pc < p.lineinfo.length? String.valueOf(p.lineinfo[pc]): "?");
+			+ (p.lineinfo != null && pc >= 0 && pc < p.lineinfo.length? String.valueOf(p.lineinfo[pc]): "?") + ": ";
 		le.traceback = errorHook(le.getMessage(), le.level);
 	}
 	

--- a/src/core/org/luaj/vm2/LuaClosure.java
+++ b/src/core/org/luaj/vm2/LuaClosure.java
@@ -122,11 +122,11 @@ public class LuaClosure extends LuaFunction {
 	public LuaClosure checkclosure() {
 		return this;
 	}
-	
+
 	public String tojstring() {
 		return "function: " + p.toString();
 	}
-	
+
 	private LuaValue[] getNewStack() {
 		int max = p.maxstacksize;
 		LuaValue[] stack = new LuaValue[max];

--- a/src/core/org/luaj/vm2/LuaDouble.java
+++ b/src/core/org/luaj/vm2/LuaDouble.java
@@ -21,6 +21,8 @@
 ******************************************************************************/
 package org.luaj.vm2;
 
+import jdk.nashorn.internal.objects.Global;
+import org.luaj.vm2.compat.JavaCompat;
 import org.luaj.vm2.lib.MathLib;
 
 /**
@@ -242,12 +244,12 @@ public class LuaDouble extends LuaNumber {
 			
 	public String tojstring() {
 		if ( v == 0.0 ) // never occurs on J2ME
-			return (Double.doubleToRawLongBits(v)<0? "-0": "0");
+			return (JavaCompat.INSTANCE.doubleToRawLongBits(v)<0? "-0": "0");
 		long l = (long) v;
 		if ( l == v ) 
 			return Long.toString(l);
 		if ( Double.isNaN(v) )
-			return (Double.doubleToRawLongBits(v)<0? JSTR_NEGNAN: JSTR_NAN);
+			return (JavaCompat.INSTANCE.doubleToRawLongBits(v)<0? JSTR_NEGNAN: JSTR_NAN);
 		if ( Double.isInfinite(v) ) 
 			return (v<0? JSTR_NEGINF: JSTR_POSINF);
 		return Float.toString((float)v);

--- a/src/core/org/luaj/vm2/LuaDouble.java
+++ b/src/core/org/luaj/vm2/LuaDouble.java
@@ -33,8 +33,8 @@ import org.luaj.vm2.lib.MathLib;
  * <p>
  * Almost all API's implemented in LuaDouble are defined and documented in {@link LuaValue}.
  * <p>
- * However the constants {@link #NAN}, {@link #POSINF}, {@link #NEGINF},
- * {@link #JSTR_NAN}, {@link #JSTR_POSINF}, and {@link #JSTR_NEGINF} may be useful 
+ * However the constants {@link #NAN}, {@link #NEGNAN}, {@link #POSINF}, {@link #NEGINF},
+ * {@link #JSTR_NAN}, {@link #JSTR_NEGNAN}, {@link #JSTR_POSINF}, and {@link #JSTR_NEGINF} may be useful
  * when dealing with Nan or Infinite values. 
  * <p>
  * LuaDouble also defines functions for handling the unique math rules of lua devision and modulo in
@@ -55,7 +55,10 @@ public class LuaDouble extends LuaNumber {
 
 	/** Constant LuaDouble representing NaN (not a number) */
 	public static final LuaDouble NAN    = new LuaDouble( Double.NaN );
-	
+
+	/** Constant LuaDouble representing negative NaN (not a number) */
+	public static final LuaDouble NEGNAN    = new LuaDouble( -Double.NaN );
+
 	/** Constant LuaDouble representing positive infinity */
 	public static final LuaDouble POSINF = new LuaDouble( Double.POSITIVE_INFINITY );
 	
@@ -64,7 +67,10 @@ public class LuaDouble extends LuaNumber {
 	
 	/** Constant String representation for NaN (not a number), "nan" */
 	public static final String JSTR_NAN    = "nan";
-	
+
+	/** Constant String representation for negative NaN (not a number), "-nan" */
+	public static final String JSTR_NEGNAN    = "-nan";
+
 	/** Constant String representation for positive infinity, "inf" */
 	public static final String JSTR_POSINF = "inf";
 
@@ -235,17 +241,13 @@ public class LuaDouble extends LuaNumber {
 	public int strcmp( LuaString rhs )      { typerror("attempt to compare number with string"); return 0; }
 			
 	public String tojstring() {
-		/*
-		if ( v == 0.0 ) { // never occurs in J2me 
-			long bits = Double.doubleToLongBits( v );
-			return ( bits >> 63 == 0 ) ? "0" : "-0";
-		}
-		*/
+		if ( v == 0.0 ) // never occurs on J2ME
+			return (Double.doubleToRawLongBits(v)<0? "-0": "0");
 		long l = (long) v;
 		if ( l == v ) 
 			return Long.toString(l);
 		if ( Double.isNaN(v) )
-			return JSTR_NAN;
+			return (Double.doubleToRawLongBits(v)<0? JSTR_NEGNAN: JSTR_NAN);
 		if ( Double.isInfinite(v) ) 
 			return (v<0? JSTR_NEGINF: JSTR_POSINF);
 		return Float.toString((float)v);

--- a/src/core/org/luaj/vm2/LuaError.java
+++ b/src/core/org/luaj/vm2/LuaError.java
@@ -61,7 +61,7 @@ public class LuaError extends RuntimeException {
 		if (m == null)
 			return null;
 		if (fileline != null)
-			return fileline + " " + m;
+			return fileline + m;
 		return m;
 	}
 

--- a/src/core/org/luaj/vm2/LuaString.java
+++ b/src/core/org/luaj/vm2/LuaString.java
@@ -749,22 +749,87 @@ public class LuaString extends LuaValue {
 		double d = scannumber( base );
 		return Double.isNaN(d)? NIL: valueOf(d);
 	}
-	
+
+	private boolean isspace(byte c) {
+		return c == ' ' || (c >= '\t' && c <= '\r');
+	}
+
+	private boolean isdigit(byte c) {
+		return (c >= '0' && c <= '9');
+	}
+
+	private boolean isxdigit(byte c) {
+		return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+	}
+
+	private int hexvalue(byte c) {
+		return c <= '9' ? c - '0' : c <= 'F' ? c + 10 - 'A' : c + 10 - 'a';
+	}
+
 	/** 
 	 * Convert to a number in base 10, or base 16 if the string starts with '0x', 
 	 * or return Double.NaN if it cannot be converted to a number.
 	 * @return double value if conversion is valid, or Double.NaN if not 
 	 */
 	public double scannumber() {
-		int i=m_offset,j=m_offset+m_length;
-		while ( i<j && m_bytes[i]==' ' ) ++i;
-		while ( i<j && m_bytes[j-1]==' ' ) --j;
-		if ( i>=j )
+		int i = m_offset, j = m_offset + m_length;
+		while (i < j && isspace(m_bytes[i]))
+			++i;
+		while (i < j && isspace(m_bytes[j - 1]))
+			--j;
+		if (i >= j)
 			return Double.NaN;
-		if ( m_bytes[i]=='0' && i+1<j && (m_bytes[i+1]=='x'||m_bytes[i+1]=='X'))
-			return scanlong(16, i+2, j);
-		double l = scanlong(10, i, j);
-		return Double.isNaN(l)? scandouble(i,j): l;
+		if (indexOf((byte) 'x', i - m_offset) != -1 || indexOf((byte) 'X', i - m_offset) != -1)
+			return strx2number(i, j);
+		return scandouble(i, j);
+	}
+
+	private double strx2number(int start, int end) {
+		double sgn = (m_bytes[start] == '-') ? -1.0 : 1.0;
+		if (sgn == -1.0 || m_bytes[start] == '+')
+			++start;
+		if (start + 2 >= end)
+			return Double.NaN;
+		if (m_bytes[start++] != '0')
+			return Double.NaN;
+		if (m_bytes[start] != 'x' && m_bytes[start] != 'X')
+			return Double.NaN;
+		++start;
+		double m = 0;
+		int e = 0;
+		boolean i = isxdigit(m_bytes[start]);
+		while (start < end && isxdigit(m_bytes[start]))
+			m = (m * 16) + hexvalue(m_bytes[start++]);
+		if (start < end && m_bytes[start] == '.') {
+			++start;
+			while (start < end && isxdigit(m_bytes[start])) {
+				m = (m * 16) + hexvalue(m_bytes[start++]);
+				e -= 4;
+			}
+		}
+		if (!i && e == 0)
+			return Double.NaN;
+		if (start < end && (m_bytes[start] == 'p' || m_bytes[start] == 'P')) {
+			++start;
+			int exp1 = 0;
+			boolean neg1 = false;
+			if (start < end) {
+				if (m_bytes[start] == '-')
+					neg1 = true;
+				if (neg1 || m_bytes[start] == '+')
+					++start;
+			}
+			if (start >= end || !isdigit(m_bytes[start]))
+				return Double.NaN;
+			while (start < end && isdigit(m_bytes[start]))
+				exp1 = exp1 * 10 + m_bytes[start++] - '0';
+			if (neg1)
+				exp1 = -exp1;
+			e += exp1;
+		}
+		if (start != end)
+			return Double.NaN;
+		return sgn * m * MathLib.dpow_d(2.0, e);
 	}
 	
 	/** 
@@ -776,8 +841,8 @@ public class LuaString extends LuaValue {
 		if ( base < 2 || base > 36 )
 			return Double.NaN;
 		int i=m_offset,j=m_offset+m_length;
-		while ( i<j && m_bytes[i]==' ' ) ++i;
-		while ( i<j && m_bytes[j-1]==' ' ) --j;
+		while ( i<j && isspace(m_bytes[i]) ) ++i;
+		while ( i<j && isspace(m_bytes[j-1]) ) --j;
 		if ( i>=j )
 			return Double.NaN;
 		return scanlong( base, i, j );
@@ -794,7 +859,8 @@ public class LuaString extends LuaValue {
 	private double scanlong( int base, int start, int end ) {
 		long x = 0;
 		boolean neg = (m_bytes[start] == '-');
-		for ( int i=(neg?start+1:start); i<end; i++ ) {
+		if (neg || m_bytes[start] == '+') start++;
+		for ( int i=start; i<end; i++ ) {
 			int digit = m_bytes[i] - (base<=10||(m_bytes[i]>='0'&&m_bytes[i]<='9')? '0':
 					m_bytes[i]>='A'&&m_bytes[i]<='Z'? ('A'-10): ('a'-10));
 			if ( digit < 0 || digit >= base )

--- a/src/core/org/luaj/vm2/LuaValue.java
+++ b/src/core/org/luaj/vm2/LuaValue.java
@@ -1053,7 +1053,7 @@ public class LuaValue extends Varargs {
 	 * @param expected String naming the type that was expected
 	 * @throws LuaError in all cases
 	 */
-	protected LuaValue argerror(String expected) { throw new LuaError("bad argument: "+expected+" expected, got "+typename()); }
+	protected LuaValue argerror(String expected) { throw new LuaError("bad argument ("+expected+" expected, got "+typename()+")"); }
 	
 	/**
 	 * Throw a {@link LuaError} indicating an invalid argument was supplied to a function
@@ -1061,7 +1061,7 @@ public class LuaValue extends Varargs {
 	 * @param msg String providing information about the invalid argument
 	 * @throws LuaError in all cases
 	 */
-	public static LuaValue argerror(int iarg,String msg) { throw new LuaError("bad argument #"+iarg+": "+msg); }
+	public static LuaValue argerror(int iarg,String msg) { throw new LuaError("bad argument #"+iarg+" ("+msg+")"); }
 	
 	/**
 	 * Throw a {@link LuaError} indicating an invalid type was supplied to a function

--- a/src/core/org/luaj/vm2/LuaValue.java
+++ b/src/core/org/luaj/vm2/LuaValue.java
@@ -99,7 +99,7 @@ package org.luaj.vm2;
  * {@link #INDEX}, {@link #NEWINDEX}, {@link #CALL}, {@link #MODE}, {@link #METATABLE},
  * {@link #ADD}, {@link #SUB}, {@link #DIV}, {@link #MUL}, {@link #POW},
  * {@link #MOD}, {@link #UNM}, {@link #LEN}, {@link #EQ}, {@link #LT},
- * {@link #LE}, {@link #TOSTRING}, and {@link #CONCAT}.
+ * {@link #LE}, {@link #TOSTRING}, {@link #CONCAT}, {@link PAIRS} and {@link IPAIRS}.
  * 
  * @see org.luaj.vm2.lib.jse.JsePlatform
  * @see org.luaj.vm2.lib.jme.JmePlatform
@@ -242,7 +242,13 @@ public class LuaValue extends Varargs {
 
 	/** LuaString constant with value "__concat" for use as metatag */
 	public static final LuaString CONCAT      = valueOf("__concat");
-	
+
+	/** LuaString constant with value "__pairs" for use as metatag */
+	public static final LuaString PAIRS = valueOf("__pairs");
+
+	/** LuaString constant with value "__ipairs" for use as metatag */
+	public static final LuaString IPAIRS = valueOf("__ipairs");
+
 	/** LuaString constant with value "" */
 	public static final LuaString EMPTYSTRING = valueOf("");
 

--- a/src/core/org/luaj/vm2/LuaValue.java
+++ b/src/core/org/luaj/vm2/LuaValue.java
@@ -529,7 +529,7 @@ public class LuaValue extends Varargs {
 	 * @see #isstring()
 	 * @see #TSTRING
 	 */
-	public String  tojstring()           { return typename() + ": " + Integer.toHexString(hashCode()); }
+	public String  tojstring()           { return typename() + ": 0x" + Integer.toHexString(hashCode()); }
 	
 	/** Convert to userdata instance, or null.
 	 * @return userdata instance if userdata, or null if not {@link LuaUserdata}

--- a/src/core/org/luaj/vm2/compat/JavaCompat.java
+++ b/src/core/org/luaj/vm2/compat/JavaCompat.java
@@ -1,0 +1,19 @@
+package org.luaj.vm2.compat;
+
+public class JavaCompat {
+    public static final JavaCompat INSTANCE;
+
+    static {
+        JavaCompat instance;
+        try {
+            instance = (JavaCompat) Class.forName("org.luaj.vm2.lib.jse.JavaCompatJSE").newInstance();
+        } catch (Throwable t) {
+            instance = new JavaCompat();
+        }
+        INSTANCE = instance;
+    }
+
+    public long doubleToRawLongBits(double x) {
+        return Double.doubleToLongBits(x);
+    }
+}

--- a/src/core/org/luaj/vm2/compiler/FuncState.java
+++ b/src/core/org/luaj/vm2/compiler/FuncState.java
@@ -97,7 +97,7 @@ public class FuncState extends Constants {
 		for (i = bl.firstlabel; i < ll_n; i++) {
 			if (label.eq_b(ll[i].name)) {
 				String msg = ls.L.pushfstring(
-                          "label '" + label + " already defined on line " + ll[i].line);
+                          "label '" + label + "' already defined on line " + ll[i].line);
 				ls.semerror(msg);
 			}
 		}

--- a/src/core/org/luaj/vm2/compiler/LexState.java
+++ b/src/core/org/luaj/vm2/compiler/LexState.java
@@ -150,7 +150,7 @@ public class LexState extends Constants {
 	    "in", "local", "nil", "not", "or", "repeat",
 	    "return", "then", "true", "until", "while",
 	    "..", "...", "==", ">=", "<=", "~=",
-	    "::", "<eos>", "<number>", "<name>", "<string>", "<eof>",
+	    "::", "<eof>", "<number>", "<name>", "<string>"
 	};
 
 	final static int
@@ -161,7 +161,7 @@ public class LexState extends Constants {
 		TK_RETURN=274, TK_THEN=275, TK_TRUE=276, TK_UNTIL=277, TK_WHILE=278,
 		/* other terminal symbols */
 		TK_CONCAT=279, TK_DOTS=280, TK_EQ=281, TK_GE=282, TK_LE=283, TK_NE=284,
-		TK_DBCOLON=285, TK_EOS=286, TK_NUMBER=287, TK_NAME=288, TK_STRING=289;
+		TK_DBCOLON=285, TK_EOF=286, TK_NUMBER=287, TK_NAME=288, TK_STRING=289;
 	  
 	final static int FIRST_RESERVED = TK_AND;
 	final static int NUM_RESERVED = TK_WHILE+1-FIRST_RESERVED;
@@ -292,7 +292,7 @@ public class LexState extends Constants {
 	void setinput(LuaC.CompileState L, int firstByte, InputStream z, LuaString source) {
 		this.decpoint = '.';
 		this.L = L;
-		this.lookahead.token = TK_EOS; /* no look-ahead token */
+		this.lookahead.token = TK_EOF; /* no look-ahead token */
 		this.z = z;
 		this.fs = null;
 		this.linenumber = 1;
@@ -434,7 +434,7 @@ public class LexState extends Constants {
 			switch (current) {
 			case EOZ:
 				lexerror((seminfo != null) ? "unfinished long string"
-						: "unfinished long comment", TK_EOS);
+						: "unfinished long comment", TK_EOF);
 				break; /* to avoid warnings */
 			case '[': {
 				if (skip_sep() == sep) {
@@ -498,7 +498,7 @@ public class LexState extends Constants {
 		while (current != del) {
 			switch (current) {
 			case EOZ:
-				lexerror("unfinished string", TK_EOS);
+				lexerror("unfinished string", TK_EOF);
 				continue; /* to avoid warnings */
 			case '\n':
 			case '\r':
@@ -685,7 +685,7 @@ public class LexState extends Constants {
 		        return TK_NUMBER;
 		    }
 		 	case EOZ: {
-				return TK_EOS;
+				return TK_EOF;
 			}
 			default: {
 				if (isspace(current)) {
@@ -720,15 +720,15 @@ public class LexState extends Constants {
 
 	void next() {
 		lastline = linenumber;
-		if (lookahead.token != TK_EOS) { /* is there a look-ahead token? */
+		if (lookahead.token != TK_EOF) { /* is there a look-ahead token? */
 			t.set( lookahead ); /* use this one */
-			lookahead.token = TK_EOS; /* and discharge it */
+			lookahead.token = TK_EOF; /* and discharge it */
 		} else
 			t.token = llex(t.seminfo); /* read next token */
 	}
 
 	void lookahead() {
-		_assert (lookahead.token == TK_EOS);
+		_assert (lookahead.token == TK_EOF);
 		lookahead.token = llex(lookahead.seminfo);
 	}
 
@@ -839,8 +839,8 @@ public class LexState extends Constants {
 	------------------------------------------------------------------------*/
 	
 	void anchor_token () {
-		/* last token from outer function must be EOS */
-		_assert(fs != null || t.token == TK_EOS);
+		/* last token from outer function must be EOF */
+		_assert(fs != null || t.token == TK_EOF);
 		if (t.token == TK_NAME || t.token == TK_STRING) {
 			LuaString ts = t.seminfo.ts;
 			// TODO: is this necessary?
@@ -1608,7 +1608,7 @@ public class LexState extends Constants {
 
 	boolean block_follow (boolean withuntil) {
 		switch (t.token) {
-		    case TK_ELSE: case TK_ELSEIF: case TK_END: case TK_EOS:
+		    case TK_ELSE: case TK_ELSEIF: case TK_END: case TK_EOF:
 		    	return true;
 			case TK_UNTIL:
 		    	return withuntil;
@@ -2140,7 +2140,7 @@ public class LexState extends Constants {
 		  fs.newupvalue(envn, v);  /* ...set environment upvalue */
 		  next();  /* read first token */
 		  statlist();  /* parse main body */
-		  check(TK_EOS);
+		  check(TK_EOF);
 		  close_func();
 	}
 	

--- a/src/core/org/luaj/vm2/lib/BaseLib.java
+++ b/src/core/org/luaj/vm2/lib/BaseLib.java
@@ -78,7 +78,6 @@ import org.luaj.vm2.Varargs;
 public class BaseLib extends TwoArgFunction implements ResourceFinder {
 	
 	Globals globals;
-	
 
 	/** Perform one-time initialization on the library by adding base functions
 	 * to the supplied environment, and returning it as the return value.

--- a/src/core/org/luaj/vm2/lib/BaseLib.java
+++ b/src/core/org/luaj/vm2/lib/BaseLib.java
@@ -350,8 +350,11 @@ public class BaseLib extends TwoArgFunction implements ResourceFinder {
 	static final class tostring extends LibFunction {
 		public LuaValue call(LuaValue arg) {
 			LuaValue h = arg.metatag(TOSTRING);
-			if ( ! h.isnil() )
-				return h.call(arg);
+			if ( ! h.isnil() ) {
+				LuaValue v = h.call(arg);
+				LuaValue vs = v.tostring();
+				return !vs.isnil() ? vs : v;
+			}
 			LuaValue v = arg.tostring();
 			if ( ! v.isnil() )
 				return v;

--- a/src/core/org/luaj/vm2/lib/LibFunction.java
+++ b/src/core/org/luaj/vm2/lib/LibFunction.java
@@ -196,7 +196,7 @@ abstract public class LibFunction extends LuaFunction {
 	}
 
 	public LuaValue call() {
-		return argerror(1,"value");
+		return argerror(1,"value expected");
 	}
 	public LuaValue call(LuaValue a) {
 		return call();

--- a/src/core/org/luaj/vm2/lib/StringLib.java
+++ b/src/core/org/luaj/vm2/lib/StringLib.java
@@ -24,12 +24,8 @@ package org.luaj.vm2.lib;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
-import org.luaj.vm2.Buffer;
-import org.luaj.vm2.LuaClosure;
-import org.luaj.vm2.LuaString;
-import org.luaj.vm2.LuaTable;
-import org.luaj.vm2.LuaValue;
-import org.luaj.vm2.Varargs;
+import org.luaj.vm2.*;
+import org.luaj.vm2.compat.JavaCompat;
 import org.luaj.vm2.compiler.DumpState;
 
 /**
@@ -274,8 +270,41 @@ public class StringLib extends TwoArgFunction {
 							case 'f':
 							case 'g':
 							case 'G':
-								fdsc.format( result, args.checkdouble( arg ) );
-								break;
+								case 'a':
+								case 'A':
+									double j = args.checkdouble(arg);
+									if (Double.isNaN(j) || Double.isInfinite(j)) {
+										String nprefix = "";
+										if (JavaCompat.INSTANCE.doubleToRawLongBits(j) < 0)
+											nprefix = "-";
+										else if (fdsc.explicitPlus)
+											nprefix = "+";
+										else if (fdsc.space)
+											nprefix = " ";
+										String bstr = Double.isNaN(j) ? LuaDouble.JSTR_NAN : LuaDouble.JSTR_POSINF;
+										if (fdsc.conversion == 'E' || fdsc.conversion == 'G')
+											bstr = bstr.toUpperCase();
+										fdsc.precision = -1;
+										fdsc.zeroPad = false;
+										fdsc.format(result, valueOf(nprefix + bstr));
+									} else if ((fdsc.conversion == 'g' || fdsc.conversion == 'G') && fdsc.precision == -1) {
+										//TODO: This gives a slightly different format but is better than nothing
+										String nprefix = "";
+										if (j >= 0) {
+											if (fdsc.explicitPlus)
+												nprefix = "+";
+											else if (fdsc.space)
+												nprefix = " ";
+										}
+										String bstr = Double.toString(j);
+										if (fdsc.conversion == 'G')
+											bstr = bstr.toUpperCase();
+										else
+											bstr = bstr.toLowerCase();
+										fdsc.format(result, valueOf(nprefix + bstr));
+									} else
+										fdsc.format(result, args.checkdouble(arg));
+									break;
 							case 'q':
 								addquoted( result, args.checkstring( arg ) );
 								break;
@@ -374,9 +403,9 @@ public class StringLib extends TwoArgFunction {
 					c = ( (p < n) ? strfrmt.luaByte( p++ ) : 0 );
 				}
 			}
-			
-			precision = -1;
+
 			if ( c == '.' ) {
+				precision = 0;
 				c = ( (p < n) ? strfrmt.luaByte( p++ ) : 0 );
 				if ( Character.isDigit( (char) c ) ) {
 					precision = c - '0';
@@ -386,20 +415,32 @@ public class StringLib extends TwoArgFunction {
 						c = ( (p < n) ? strfrmt.luaByte( p++ ) : 0 );
 					}
 				}
-			}
-			
+			} else
+				precision = -1;
+
 			if ( Character.isDigit( (char) c ) )
 				error("invalid format (width or precision too long)");
-			
-			zeroPad &= !leftAdjust; // '-' overrides '0'
+
+			if ( width == -1 ) {
+				// default width overrides '-' and '0'
+				leftAdjust = false;
+				zeroPad = false;
+			} else
+				zeroPad &= !leftAdjust; // '-' overrides '0'
+			space &= !explicitPlus; // '+' overrides ' '
 			conversion = c;
 			length = p - start;
 			src = strfrmt.substring(start - 1, p).tojstring();
 		}
 		
 		public void format(Buffer buf, byte c) {
-			// TODO: not clear that any of width, precision, or flags apply here.
+			if (!leftAdjust)
+				pad(buf, ' ', width - 1);
+
 			buf.append(c);
+
+			if (leftAdjust)
+				pad(buf, ' ', width - 1);
 		}
 		
 		public void format(Buffer buf, long number) {
@@ -429,10 +470,12 @@ public class StringLib extends TwoArgFunction {
 			int minwidth = digits.length();
 			int ndigits = minwidth;
 			int nzeros;
+
+			boolean allowPlusSpace = conversion == 'd' || conversion == 'i';
 			
 			if ( number < 0 ) {
 				ndigits--;
-			} else if ( explicitPlus || space ) {
+			} else if ( allowPlusSpace && (explicitPlus || space) ) {
 				minwidth++;
 			}
 			
@@ -454,12 +497,26 @@ public class StringLib extends TwoArgFunction {
 					buf.append( (byte)'-' );
 					digits = digits.substring( 1 );
 				}
-			} else if ( explicitPlus ) {
+			} else if ( allowPlusSpace && explicitPlus ) {
 				buf.append( (byte)'+' );
-			} else if ( space ) {
+			} else if ( allowPlusSpace && space ) {
 				buf.append( (byte)' ' );
 			}
-			
+
+			if (alternateForm) {
+				switch (conversion) {
+					case 'o':
+						buf.append((byte) '0');
+						break;
+					case 'x':
+						buf.append("0x");
+						break;
+					case 'X':
+						buf.append("0X");
+						break;
+				}
+			}
+
 			if ( nzeros > 0 )
 				pad( buf, '0', nzeros );
 			
@@ -470,14 +527,40 @@ public class StringLib extends TwoArgFunction {
 		}
 		
 		public void format(Buffer buf, double x) {
-			buf.append( StringLib.this.format(src, x) );
+			// TODO: Java does not support alternateForm with 'g'
+			String sFormat = "%";
+			if (leftAdjust)
+				sFormat += ("-");
+			if (explicitPlus)
+				sFormat += ("+");
+			if (space)
+				sFormat += (" ");
+			if (alternateForm && conversion != 'g' && conversion != 'G')
+				sFormat += ("#");
+			if (zeroPad)
+				sFormat += ("0");
+			if (width != -1)
+				sFormat += (width);
+			if (precision != -1)
+				sFormat += (".") + (precision);
+			sFormat += ((char) conversion);
+			buf.append( StringLib.this.format(sFormat, x) );
 		}
 		
 		public void format(Buffer buf, LuaString s) {
 			int nullindex = s.indexOf( (byte)'\0', 0 );
 			if ( nullindex != -1 )
 				s = s.substring( 0, nullindex );
+
+			int newLength = precision == -1 ? s.length() : Math.min(precision, s.length());
+
+			if (!leftAdjust)
+				pad(buf, zeroPad ? '0' : ' ', width - newLength);
+
 			buf.append(s);
+
+			if (leftAdjust)
+				pad(buf, ' ', width - newLength);
 		}
 		
 		public final void pad(Buffer buf, char c, int n) {

--- a/src/core/org/luaj/vm2/lib/StringLib.java
+++ b/src/core/org/luaj/vm2/lib/StringLib.java
@@ -667,22 +667,35 @@ public class StringLib extends TwoArgFunction {
 			return str_find_aux( args, false );
 		}
 	}
-	
+
 	/**
-	 * string.rep (s, n)
-	 * 
-	 * Returns a string that is the concatenation of n copies of the string s.
+	 * string.rep (s, n [, sep])
+	 *
+	 * Returns a string that is the concatenation of n copies of the string s
+	 * separated by the string sep. The default value for sep is the empty
+	 * string (that is, no separator).
 	 */
 	static final class rep extends VarArgFunction {
 		public Varargs invoke(Varargs args) {
-			LuaString s = args.checkstring( 1 );
-			int n = args.checkint( 2 );
-			final byte[] bytes = new byte[ s.length() * n ];
+			LuaString s = args.checkstring(1);
+			int n = args.checkint(2);
+			LuaString sep = args.optstring(3, EMPTYSTRING);
+			if (n <= 0)
+				return EMPTYSTRING;
 			int len = s.length();
-			for ( int offset = 0; offset < bytes.length; offset += len ) {
-				s.copyInto( 0, bytes, offset, len );
+			int lsep = sep.length();
+			final byte[] bytes = new byte[len * n + lsep * (n - 1)];
+			int offset = 0;
+			while (n-- > 1) {
+				s.copyInto(0, bytes, offset, len);
+				offset += len;
+				if (lsep > 0) {
+					sep.copyInto(0, bytes, offset, lsep);
+					offset += lsep;
+				}
 			}
-			return LuaString.valueUsing( bytes );
+			s.copyInto(0, bytes, offset, len);
+			return LuaString.valueUsing(bytes);
 		}
 	}
 

--- a/src/jse/org/luaj/vm2/lib/jse/JavaCompatJSE.java
+++ b/src/jse/org/luaj/vm2/lib/jse/JavaCompatJSE.java
@@ -1,0 +1,9 @@
+package org.luaj.vm2.lib.jse;
+
+import org.luaj.vm2.compat.JavaCompat;
+
+public class JavaCompatJSE extends JavaCompat {
+    public long doubleToRawLongBits(double x) {
+        return Double.doubleToRawLongBits(x);
+    }
+}

--- a/src/jse/org/luaj/vm2/lib/jse/JseBaseLib.java
+++ b/src/jse/org/luaj/vm2/lib/jse/JseBaseLib.java
@@ -73,7 +73,6 @@ import org.luaj.vm2.lib.ResourceFinder;
 
 public class JseBaseLib extends org.luaj.vm2.lib.BaseLib {
 
-
 	/** Perform one-time initialization on the library by creating a table
 	 * containing the library functions, adding that table to the supplied environment,
 	 * adding the table to package.loaded, and returning table as the return value.


### PR DESCRIPTION
The source for all of these fixes is the "OpenComputers" Minecraft mod, which utilized LuaJ as one of its Lua engines for years - specifically: https://github.com/MightyPirates/OC-LuaJ ; their main goal was to remove disparities between real Lua 5.2 and LuaJ.

Most of my work in this pertains to ensuring the code still compiles in J2ME, as well as splitting up the large commits into smaller ones. Feel free to only merge some of these fixes, if some are not applicable to LuaJ.