### PR TITLE
update for support of modern JDKs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ jit/
 *.zip
 docs
 *.0
+.java-version

--- a/README.md
+++ b/README.md
@@ -1,4 +1,29 @@
 # This is a fork!
+
+This fork aims to fix some issues met with luaj 3.0.2, still present in 
+[luaj/luaj](https://github.com/luaj/luaj) at
+this time of writing.
+
+Building the version 3.0.2 with recent versions of ant (e.g. 1.10.11) and
+JDK (8+) seems no longer possible. Issuing the `ant` command will fail
+with the following error:
+
+```
+[javac] error: Source option 1.3 is no longer supported. Use 7 or later.
+[javac] error: Target option 1.2 is no longer supported. Use 7 or later.
+```
+
+The `build.xml` file of this fork has been refactored in order to separate
+jme and jse targets, and to upgrade the jse target to more recent versions
+of the JDK (namely 1.8+).
+
+It is now possible to build the jse target alone with: `ant jar-jse`
+
+The `jar-jme` target from 3.0.2 will be left unchanged until contributors
+experienced with JME be ready to join the project.
+
+# Original README.md
+
 <div style="border: 1px dotted red; margin: 1.em 0.5em; font-weight: bold; color: red;">
 This repository has been forked from the original CVS sources of Luaj.
 The commit history has been converted to make sure that the original work of

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ It is now possible to build the jse target alone with: `ant jar-jse`
 The `jar-jme` target from 3.0.2 will be left unchanged until contributors
 experienced with JME be ready to join the project.
 
+The interpreter can be tested with `luaj` (on POSIX systems) or `luaj.bat`
+(on Windows systems). These commands can be passed arguments.
+
 # Original README.md
 
 <div style="border: 1px dotted red; margin: 1.em 0.5em; font-weight: bold; color: red;">

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Then test with: `./luaj`
 (or `luaj.bat` on Windows)
 
 If you need JME support (Java Micro Edition, specifically for mobiles),
-this fork is not recommend.
+this fork is not recommended.
 
-You can try `ant all` or `ant jar-jme`, but there is no no guarantee that it
+You can try `ant all` or `ant jar-jme`, but there is no guarantee that it
 will even compile (though that may be fixed in a future version).
 
 This fork aims to fix some issues met with luaj 3.0.2, still present in 
@@ -19,13 +19,7 @@ This fork aims to fix some issues met with luaj 3.0.2, still present in
 this time of writing.
 
 Building the version 3.0.2 with recent versions of ant (e.g. 1.10.11) and
-JDK (8+) seems no longer possible. Issuing the `ant` command will fail
-with the following error:
-
-```
-[javac] error: Source option 1.3 is no longer supported. Use 7 or later.
-[javac] error: Target option 1.2 is no longer supported. Use 7 or later.
-```
+JDK (8+) seems no longer possible.
 
 The `build.xml` file of this fork has been refactored in order to separate
 jme and jse targets, and to upgrade the jse target to more recent versions
@@ -33,7 +27,7 @@ of the JDK (namely 1.8+).
 
 It is now possible to build the jse target alone with: `ant jar-jse`
 
-The `jar-jme` target from 3.0.2 will be left unchanged until contributors
+The `jar-jme` target from 3.0.2 won't be supported until contributors
 experienced with JME be ready to join the project.
 
 The interpreter can be tested with `luaj` (on POSIX systems) or `luaj.bat`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ this fork is not recommended.
 
 You can try `ant all` or `ant jar-jme`, but there is no guarantee that it
 will even compile (though that may be fixed in a future version).
+The `TODO` file can contain information about some known issues.
 
 This fork aims to fix some issues met with luaj 3.0.2, still present in 
 [luaj/luaj](https://github.com/luaj/luaj) at

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 Compile with: `ant` or `ant jar-jse`
 
+(this will build only the project for Java Standard Edition)
+
 Then test with: `./luaj`
 
 (or `luaj.bat` on Windows)
 
-There is no guarantee that `ant all` still compiles for the moment
-(though that may be fixed in a future version).
+If you need JME support (Java Micro Edition, specifically for mobiles),
+this fork is not recommend.
+
+You can try `ant all` or `ant jar-jme`, but there is no no guarantee that it
+will even compile (though that may be fixed in a future version).
 
 This fork aims to fix some issues met with luaj 3.0.2, still present in 
 [luaj/luaj](https://github.com/luaj/luaj) at

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # This is a fork!
 
+Compile with: `ant` or `ant jar-jse`
+
+There is no guarantee that `ant all` still compiles for the moment
+(though that may be fixed in a future version).
+
 This fork aims to fix some issues met with luaj 3.0.2, still present in 
 [luaj/luaj](https://github.com/luaj/luaj) at
 this time of writing.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Compile with: `ant` or `ant jar-jse`
 
+Then test with: `./luaj`
+
+(or `luaj.bat` on Windows)
+
 There is no guarantee that `ant all` still compiles for the moment
 (though that may be fixed in a future version).
 

--- a/TODO
+++ b/TODO
@@ -10,7 +10,7 @@ with java.lang.StringBuilder
 
 Unfortunately, this class is not available in the JME environment.
 
-A workaround would be to replaced the + concatenation with the String.concat() method, like this:
+A workaround would be to replace the + concatenation with the String.concat() method, like this:
 
 -       public String  tojstring()           { return typename() + ": " + Integer.toHexString(hashCode()); }
 +       public String  tojstring()           { return typename().concat(": ").concat(Integer.toHexString(hashCode())); }

--- a/TODO
+++ b/TODO
@@ -1,0 +1,20 @@
+The current version doesn't compile with:
+ant jar-jme|all
+
+The Java compiler complains with an obscure error:
+    [javac] /Users/ducos/Projects/luaj/build/jme/src/org/luaj/vm2/LuaValue.java:532: error: cannot access StringBuilder
+    [javac] 	public String  tojstring()           { return typename() + ": " + Integer.toHexString(hashCode()); }
+
+This is because, in recent versions of Java, the concatenation of strings is automatically performed
+with java.lang.StringBuilder
+
+Unfortunately, this class is not available in the JME environment.
+
+A workaround would be to replaced the + concatenation with the String.concat() method, like this:
+
+-       public String  tojstring()           { return typename() + ": " + Integer.toHexString(hashCode()); }
++       public String  tojstring()           { return typename().concat(": ").concat(Integer.toHexString(hashCode())); }
+
+But it has to be done everywhere in the code.
+
+Maybe there is a more straightforward method, with a compiler's flag.

--- a/build-applet.xml
+++ b/build-applet.xml
@@ -33,7 +33,7 @@
 		<copy todir="${build.dir}">
 			<fileset dir="${script.dir}" includes="${script.name}.lua,${image.name}"/>
 		</copy>
-		<javac destdir="${build.dir}/classes" source="1.4" target="1.4" 
+		<javac destdir="${build.dir}/classes" source="1.8" target="1.8" 
 			classpath="${luaj.jar}" srcdir="${java.dir}" includes="${java.name}.java"/>
 	</target>
 

--- a/build-applet.xml
+++ b/build-applet.xml
@@ -70,7 +70,7 @@
 			
 			-keep public class * extends java.applet.Applet
 
-			-target 1.4
+			-target 1.8
 		</proguard>		 
 	</target>
 
@@ -95,7 +95,7 @@
     			    width='800' 
     			    height='640' >
 	                <param name='luaj.script' value='${script.name}.lua'/>
-    				<param name="java_version" value="1.4+"/>
+    				<param name="java_version" value="1.8+"/>
     			</applet>
     		</body>
     		</html>     		

--- a/build-coverage.xml
+++ b/build-coverage.xml
@@ -46,7 +46,7 @@
 	</target>
 
 	<target name="compile" depends="init,wtk-or-fail">
-		<javac destdir="${classes.dir}" debug="yes" target="1.5">
+		<javac destdir="${classes.dir}" debug="yes" target="1.8">
 			<classpath refid="cobertura.classpath" />
 		    <classpath refid="wtk-libs" />
 		    <classpath path="lib/bcel-5.2.jar" />

--- a/build-midlet.xml
+++ b/build-midlet.xml
@@ -59,7 +59,7 @@
 			<pathelement path="lib/midpapi20.jar"/>
 			<pathelement path="lib/mmapi.jar"/>
 		</path>
-		<javac destdir="build/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
+		<javac destdir="build/classes" encoding="utf-8" source="1.8" target="1.8" bootclasspathref="wtk-libs"
 			srcdir="build/midlet/src"/>
 	</target>
 

--- a/build.xml
+++ b/build.xml
@@ -33,79 +33,86 @@
 			<arg line="../../grammar/Lua52.jj"/>
 		</java>
 	</target>
-		
-	<target name="compile" depends="wtk-libs,bcel-lib">
-		<delete dir="build/jme/src"/>
-		<delete dir="build/jse/src"/>
-		<mkdir dir="build/jme/src"/>
-		<mkdir dir="build/jse/src"/>
-		<mkdir dir="build/jme/classes"/>
-		<mkdir dir="build/jse/classes"/>
-		<copy todir="build/jme/src">
-			<fileset dir="src/core"/>
-			<fileset dir="src/jme"/>
-			<filterchain>
-				<tokenfilter><replacestring from='"Luaj 0.0"' to='"Luaj-jme ${version}"'/></tokenfilter>
-			</filterchain>
-		</copy>
-		<copy todir="build/jse/src">
-			<fileset dir="src/core"/>
-			<filterchain>
-				<tokenfilter><replacestring from='"Luaj 0.0"' to='"Luaj-jse ${version}"'/></tokenfilter>
-			</filterchain>
-		</copy>
-		<copy todir="build/jse/src">
-			<fileset dir="src/jse"/>
-			<filterchain>
-				<tokenfilter><replacestring from='&lt;String&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Stat&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Exp&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Name&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Block&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;TableField&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;VarExp&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Exp.VarExp&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Object,String&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Double,String&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Integer,Integer&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Integer,LocalVariableGen&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;Exp,Integer&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;String,byte[]&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;String,Variable&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;LuaValue,String&gt;' to=''/></tokenfilter>
-				<tokenfilter><replacestring from='&lt;LuaString,String&gt;' to=''/></tokenfilter>
-			</filterchain>
-		</copy>
-		<path id="wtk-libs">
-			<pathelement path="lib/cldcapi11.jar"/>
-			<pathelement path="lib/midpapi20.jar"/>
-			<pathelement path="lib/mmapi.jar"/>
-		</path>
-		<javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
-		    debug="on"
-			srcdir="build/jme/src"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
-			classpath="lib/bcel-5.2.jar"
-			debug="on"
-			srcdir="build/jse/src"
-			excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.5" target="1.5"
-			classpath="build/jse/classes"
-			debug="on"
-			srcdir="build/jse/src"
-			includes="**/script/*,**/Lua2Java*,**/server/*"/>
-		<javac destdir="build/jse/classes" encoding="utf-8" source="1.3" target="1.3"
-			classpath="build/jse/classes"
-			debug="on"
-			srcdir="build/jse/src"
-			includes="lua*"/>
+
+	<target name="compile-jme" depends="wtk-libs,bcel-lib">
+	  <delete dir="build/jme/src"/>
+	  <mkdir dir="build/jme/src"/>
+	  <mkdir dir="build/jme/classes"/>
+	  <copy todir="build/jme/src">
+	    <fileset dir="src/core"/>
+	    <fileset dir="src/jme"/>
+	    <filterchain>
+	      <tokenfilter><replacestring from='"Luaj 0.0"' to='"Luaj-jme ${version}"'/></tokenfilter>
+	    </filterchain>
+	  </copy>
+
+	  <path id="wtk-libs">
+	    <pathelement path="lib/cldcapi11.jar"/>
+	    <pathelement path="lib/midpapi20.jar"/>
+	    <pathelement path="lib/mmapi.jar"/>
+	  </path>
+	  <javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
+		 debug="on"
+		 srcdir="build/jme/src"/>
 	</target>
+
+	<target name="compile-jse" depends="wtk-libs,bcel-lib">
+	  <delete dir="build/jse/src"/>
+	  <mkdir dir="build/jse/src"/>
+	  <mkdir dir="build/jse/classes"/>
+	  <copy todir="build/jse/src">
+	    <fileset dir="src/core"/>
+	    <filterchain>
+	      <tokenfilter><replacestring from='"Luaj 0.0"' to='"Luaj-jse ${version}"'/></tokenfilter>
+	    </filterchain>
+	  </copy>
+	  <copy todir="build/jse/src">
+	    <fileset dir="src/jse"/>
+	    <filterchain>
+	      <tokenfilter><replacestring from='&lt;String&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Stat&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Exp&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Name&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Block&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;TableField&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;VarExp&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Exp.VarExp&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Object,String&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Double,String&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Integer,Integer&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Integer,LocalVariableGen&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;Exp,Integer&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;String,byte[]&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;String,Variable&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;LuaValue,String&gt;' to=''/></tokenfilter>
+	      <tokenfilter><replacestring from='&lt;LuaString,String&gt;' to=''/></tokenfilter>
+	    </filterchain>
+	  </copy>
+	  
+	  <javac destdir="build/jse/classes" encoding="utf-8" source="1.8" target="1.8"
+		 classpath="lib/bcel-5.2.jar"
+		 debug="on"
+		 srcdir="build/jse/src"
+		 excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
+	  <javac destdir="build/jse/classes" encoding="utf-8" source="1.8" target="1.8"
+		 classpath="build/jse/classes"
+		 debug="on"
+		 srcdir="build/jse/src"
+		 includes="**/script/*,**/Lua2Java*,**/server/*"/>
+	  <javac destdir="build/jse/classes" encoding="utf-8" source="1.8" target="1.8"
+		 classpath="build/jse/classes"
+		 debug="on"
+		 srcdir="build/jse/src"
+		 includes="lua*"/>
+	</target>
+		
+	<target name="compile" depends="compile-jme,compile-jse" />
 	
-	<target name="jar-jme" depends="compile">
+	<target name="jar-jme" depends="compile-jme">
 		<jar destfile="${jar.name.jme}" basedir="build/jme/classes"/>
 	</target>
 	
-	<target name="jar-jse" depends="compile">
+	<target name="jar-jse" depends="compile-jse">
 		<jar destfile="${jar.name.jse}">
 		    <fileset dir="build/jse/classes"/>
 		    <fileset dir="src/jse/">

--- a/build.xml
+++ b/build.xml
@@ -1,4 +1,4 @@
-<project default="all">
+<project default="jar-jse">
 	<property file="version.properties"/>
 		
 	<property name="jar.name.jme" value="luaj-jme-${version}.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -93,17 +93,23 @@
 		 classpath="lib/bcel-5.2.jar"
 		 debug="on"
 		 srcdir="build/jse/src"
-		 excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"/>
+		 excludes="**/script/*,**/Lua2Java*,**/server/*,lua*"
+		 includeantruntime="false"
+          />
 	  <javac destdir="build/jse/classes" encoding="utf-8" source="1.8" target="1.8"
 		 classpath="build/jse/classes"
 		 debug="on"
 		 srcdir="build/jse/src"
-		 includes="**/script/*,**/Lua2Java*,**/server/*"/>
+		 includes="**/script/*,**/Lua2Java*,**/server/*"
+		 includeantruntime="false"
+          />
 	  <javac destdir="build/jse/classes" encoding="utf-8" source="1.8" target="1.8"
 		 classpath="build/jse/classes"
 		 debug="on"
 		 srcdir="build/jse/src"
-		 includes="lua*"/>
+		 includes="lua*"
+		 includeantruntime="false"
+          />
 	</target>
 		
 	<target name="compile" depends="compile-jme,compile-jse" />

--- a/build.xml
+++ b/build.xml
@@ -51,7 +51,7 @@
 	    <pathelement path="lib/midpapi20.jar"/>
 	    <pathelement path="lib/mmapi.jar"/>
 	  </path>
-	  <javac destdir="build/jme/classes" encoding="utf-8" source="1.3" target="1.2" bootclasspathref="wtk-libs"
+	  <javac includeantruntime="false" destdir="build/jme/classes" encoding="utf-8" source="1.8" target="1.8" bootclasspathref="wtk-libs"
 		 debug="on"
 		 srcdir="build/jme/src"/>
 	</target>

--- a/grammar/Lua51.jj
+++ b/grammar/Lua51.jj
@@ -15,7 +15,7 @@
 
 options {
   STATIC = false;
-  JDK_VERSION = "1.3";
+  JDK_VERSION = "1.8";
   ERROR_REPORTING = false;
   DEBUG_LOOKAHEAD = false;
   DEBUG_PARSER = false;

--- a/grammar/Lua52.jj
+++ b/grammar/Lua52.jj
@@ -15,7 +15,7 @@
 
 options {
   STATIC = false;
-  JDK_VERSION = "1.3";
+  JDK_VERSION = "1.8";
   ERROR_REPORTING = false;
   DEBUG_LOOKAHEAD = false;
   DEBUG_PARSER = false;

--- a/grammar/LuaParser.jj
+++ b/grammar/LuaParser.jj
@@ -26,7 +26,7 @@
 
 options {
   STATIC = false;
-  JDK_VERSION = "1.3";
+  JDK_VERSION = "1.8";
   ERROR_REPORTING = true;
   UNICODE_INPUT = true;
   DEBUG_LOOKAHEAD = false;

--- a/luaj
+++ b/luaj
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec jrunscript -cp luaj-jse-3.0.2.jar -l lua "$@"

--- a/luaj.bat
+++ b/luaj.bat
@@ -1,0 +1,3 @@
+@echo off
+
+jrunscript -cp luaj-jse-3.0.2.jar -l lua %*

--- a/src/core/org/luaj/vm2/compiler/FuncState.java
+++ b/src/core/org/luaj/vm2/compiler/FuncState.java
@@ -479,7 +479,7 @@ public class FuncState extends Constants {
 			return ((Integer) h.get(v)).intValue();
 		}
 		final int idx = this.nk;
-		this.h.put(v, Integer.valueOf(idx));
+		this.h.put(v, new Integer(idx));
 		final Prototype f = this.f;
 		if (f.k == null || nk + 1 >= f.k.length)
 			f.k = realloc( f.k, nk*2 + 1 );

--- a/src/core/org/luaj/vm2/compiler/FuncState.java
+++ b/src/core/org/luaj/vm2/compiler/FuncState.java
@@ -21,7 +21,8 @@
 ******************************************************************************/
 package org.luaj.vm2.compiler;
 
-import java.util.Hashtable;
+import java.util.Map;
+import java.util.HashMap;
 
 import org.luaj.vm2.LocVars;
 import org.luaj.vm2.Lua;
@@ -47,7 +48,7 @@ public class FuncState extends Constants {
 	};
 	
 	Prototype f;  /* current function header */
-	Hashtable h;  /* table to find (and reuse) elements in `k' */
+	Map<LuaValue, Integer> h;  /* table to find (and reuse) elements in `k' */
 	FuncState prev;  /* enclosing function */
 	LexState ls;  /* lexical state */
 	BlockCnt bl;  /* chain of current blocks */
@@ -474,7 +475,7 @@ public class FuncState extends Constants {
 	}
 	int addk(LuaValue v) {
 		if (this.h == null) {
-			this.h = new Hashtable();
+			this.h = new HashMap<>();
 		} else if (this.h.containsKey(v)) {
 			return ((Integer) h.get(v)).intValue();
 		}

--- a/src/core/org/luaj/vm2/compiler/FuncState.java
+++ b/src/core/org/luaj/vm2/compiler/FuncState.java
@@ -479,7 +479,7 @@ public class FuncState extends Constants {
 			return ((Integer) h.get(v)).intValue();
 		}
 		final int idx = this.nk;
-		this.h.put(v, new Integer(idx));
+		this.h.put(v, Integer.valueOf(idx));
 		final Prototype f = this.f;
 		if (f.k == null || nk + 1 >= f.k.length)
 			f.k = realloc( f.k, nk*2 + 1 );

--- a/src/core/org/luaj/vm2/compiler/FuncState.java
+++ b/src/core/org/luaj/vm2/compiler/FuncState.java
@@ -21,8 +21,7 @@
 ******************************************************************************/
 package org.luaj.vm2.compiler;
 
-import java.util.Map;
-import java.util.HashMap;
+import java.util.Hashtable;
 
 import org.luaj.vm2.LocVars;
 import org.luaj.vm2.Lua;
@@ -48,7 +47,7 @@ public class FuncState extends Constants {
 	};
 	
 	Prototype f;  /* current function header */
-	Map<LuaValue, Integer> h;  /* table to find (and reuse) elements in `k' */
+	Hashtable h;  /* table to find (and reuse) elements in `k' */
 	FuncState prev;  /* enclosing function */
 	LexState ls;  /* lexical state */
 	BlockCnt bl;  /* chain of current blocks */
@@ -475,7 +474,7 @@ public class FuncState extends Constants {
 	}
 	int addk(LuaValue v) {
 		if (this.h == null) {
-			this.h = new HashMap<>();
+			this.h = new Hashtable();
 		} else if (this.h.containsKey(v)) {
 			return ((Integer) h.get(v)).intValue();
 		}

--- a/src/core/org/luaj/vm2/compiler/LexState.java
+++ b/src/core/org/luaj/vm2/compiler/LexState.java
@@ -1391,7 +1391,7 @@ public class LexState extends Constants {
 			return;
 		}
 		default: {
-			this.syntaxerror("unexpected symbol " + t.token + " (" + ((char) t.token) + ")");
+		        this.syntaxerror("unexpected symbol near " + token2str(t.token) + " (code " + t.token + ")");
 			return;
 		}
 		}

--- a/src/core/org/luaj/vm2/compiler/LexState.java
+++ b/src/core/org/luaj/vm2/compiler/LexState.java
@@ -170,7 +170,7 @@ public class LexState extends Constants {
 	static {
 		for ( int i=0; i<NUM_RESERVED; i++ ) {
 			LuaString ts = (LuaString) LuaValue.valueOf( luaX_tokens[i] );
-			RESERVED.put(ts, Integer.valueOf(FIRST_RESERVED+i));
+			RESERVED.put(ts, new Integer(FIRST_RESERVED+i));
 		}
 	}
 

--- a/src/core/org/luaj/vm2/compiler/LexState.java
+++ b/src/core/org/luaj/vm2/compiler/LexState.java
@@ -170,7 +170,7 @@ public class LexState extends Constants {
 	static {
 		for ( int i=0; i<NUM_RESERVED; i++ ) {
 			LuaString ts = (LuaString) LuaValue.valueOf( luaX_tokens[i] );
-			RESERVED.put(ts, new Integer(FIRST_RESERVED+i));
+			RESERVED.put(ts, Integer.valueOf(FIRST_RESERVED+i));
 		}
 	}
 

--- a/src/core/org/luaj/vm2/lib/CoroutineLib.java
+++ b/src/core/org/luaj/vm2/lib/CoroutineLib.java
@@ -75,51 +75,51 @@ public class CoroutineLib extends TwoArgFunction {
 	public LuaValue call(LuaValue modname, LuaValue env) {
 		globals = env.checkglobals();
 		LuaTable coroutine = new LuaTable();
-		coroutine.set("create", new create());
-		coroutine.set("resume", new resume());
-		coroutine.set("running", new running());
-		coroutine.set("status", new status());
-		coroutine.set("yield", new yield());
-		coroutine.set("wrap", new wrap());
+		coroutine.set("create", new Create());
+		coroutine.set("resume", new Resume());
+		coroutine.set("running", new Running());
+		coroutine.set("status", new Status());
+		coroutine.set("yield", new Yield());
+		coroutine.set("wrap", new Wrap());
 		env.set("coroutine", coroutine);
 		if (!env.get("package").isnil()) env.get("package").get("loaded").set("coroutine", coroutine);
 		return coroutine;
 	}
 
-	final class create extends LibFunction {
+	final class Create extends LibFunction {
 		public LuaValue call(LuaValue f) {
 			return new LuaThread(globals, f.checkfunction());
 		}
 	}
 
-	static final class resume extends VarArgFunction {
+	static final class Resume extends VarArgFunction {
 		public Varargs invoke(Varargs args) {
 			final LuaThread t = args.checkthread(1);
 			return t.resume( args.subargs(2) );
 		}
 	}
 
-	final class running extends VarArgFunction {
+	final class Running extends VarArgFunction {
 		public Varargs invoke(Varargs args) {
 			final LuaThread r = globals.running;
 			return varargsOf(r, valueOf(r.isMainThread()));
 		}
 	}
 
-	static final class status extends LibFunction {
+	static final class Status extends LibFunction {
 		public LuaValue call(LuaValue t) {
 			LuaThread lt = t.checkthread();
 			return valueOf( lt.getStatus() );
 		}
 	}
 	
-	final class yield extends VarArgFunction {
+	final class Yield extends VarArgFunction {
 		public Varargs invoke(Varargs args) {
 			return globals.yield( args );
 		}
 	}
 
-	final class wrap extends LibFunction {
+	final class Wrap extends LibFunction {
 		public LuaValue call(LuaValue f) {
 			final LuaValue func = f.checkfunction();
 			final LuaThread thread = new LuaThread(globals, func);

--- a/src/jse/org/luaj/vm2/lib/jse/CoerceLuaToJava.java
+++ b/src/jse/org/luaj/vm2/lib/jse/CoerceLuaToJava.java
@@ -174,13 +174,13 @@ public class CoerceLuaToJava {
 
 		public Object coerce(LuaValue value) {
 			switch ( targetType ) {
-			case TARGET_TYPE_BYTE: return new Byte( (byte) value.toint() );
-			case TARGET_TYPE_CHAR: return new Character( (char) value.toint() );
-			case TARGET_TYPE_SHORT: return new Short( (short) value.toint() );
-			case TARGET_TYPE_INT: return new Integer( (int) value.toint() );
-			case TARGET_TYPE_LONG: return new Long( (long) value.todouble() );
-			case TARGET_TYPE_FLOAT: return new Float( (float) value.todouble() );
-			case TARGET_TYPE_DOUBLE: return new Double( (double) value.todouble() );
+			case TARGET_TYPE_BYTE: return Byte.valueOf( (byte) value.toint() );
+			case TARGET_TYPE_CHAR: return Character.valueOf( (char) value.toint() );
+			case TARGET_TYPE_SHORT: return Short.valueOf( (short) value.toint() );
+			case TARGET_TYPE_INT: return Integer.valueOf( (int) value.toint() );
+			case TARGET_TYPE_LONG: return Long.valueOf( (long) value.todouble() );
+			case TARGET_TYPE_FLOAT: return Float.valueOf( (float) value.todouble() );
+			case TARGET_TYPE_DOUBLE: return Double.valueOf( (double) value.todouble() );
 			default: return null;
 			}
 		}
@@ -308,7 +308,7 @@ public class CoerceLuaToJava {
 		public Object coerce(LuaValue value) {
 			switch ( value.type() ) {
 			case LuaValue.TNUMBER:
-				return value.isint()? (Object)new Integer(value.toint()): (Object)new Double(value.todouble());
+				return value.isint()? (Object) Integer.valueOf(value.toint()): (Object) Double.valueOf(value.todouble());
 			case LuaValue.TBOOLEAN:
 				return value.toboolean()? Boolean.TRUE: Boolean.FALSE;
 			case LuaValue.TSTRING:

--- a/src/jse/org/luaj/vm2/script/LuaScriptEngine.java
+++ b/src/jse/org/luaj/vm2/script/LuaScriptEngine.java
@@ -244,8 +244,8 @@ public class LuaScriptEngine extends AbstractScriptEngine implements ScriptEngin
 		case LuaValue.TSTRING: return luajValue.tojstring();
 		case LuaValue.TUSERDATA: return luajValue.checkuserdata(Object.class);
 		case LuaValue.TNUMBER: return luajValue.isinttype()? 
-				(Object) new Integer(luajValue.toint()): 
-				(Object) new Double(luajValue.todouble());
+				(Object) Integer.valueOf(luajValue.toint()): 
+				(Object) Double.valueOf(luajValue.todouble());
 		default: return luajValue;
 		}
 	}


### PR DESCRIPTION
The official luaj repository still relies on very old versions of Java and JDK (<= 1.4). It supports JSE (Java Standard Edition) and JME (Java Micro Edition, for embedded Java).

For personal needs, I have updated it to modern versions of Java (8+) and JDK in this [fork](https://github.com/fabrice-ducos/luaj). The fork has been tested successfully on several modern operating systems (Windows 10, Linux Ubuntu 21.04, MacOSX Monterey 12.6).

Unfortunately, because of limitations of JME (generics are not, and probably will never be implemented in JME, as well as StringBuilder that is now required for concatenation of strings in modern Java), the support of JME had to be removed from the fork. The code for JME is still there (and it is possible to try to compile it optionally, but it will likely not pass) and is not planned to be removed in the near future.

JME is not actively developed anymore  by Oracle and should be considered a legacy technology.

This pull request is provided as is, in the hope it might be useful for the maintainers of the official luaj repo. However, since the support of JME has been dropped in the fork (at least temporarily), they may consider not integrating these changes. This will be at the cost of staying at obsolete versions of Java (< 5).